### PR TITLE
Fixed bug reported on forum

### DIFF
--- a/scripts/manager_hp_fz.lua
+++ b/scripts/manager_hp_fz.lua
@@ -58,9 +58,11 @@ function updateNpcHitPoints(nodeNPC)
 			for _,sLine in ipairs(aLines) do
 				sLine = sLine:gsub("</?%w>", ""):lower();
 				if StringManager.startsWith(sLine, "hit points:") then
-					if tryParseHitPointLine(sLine, nodeNPC, nodeCommander) then
-						break;
-					end
+				    if (sLine:match("%d")) then
+    					if tryParseHitPointLine(sLine, nodeNPC, nodeCommander) then
+	    					break;
+		    			end
+                    end
 				end
 			end
 		end


### PR DESCRIPTION
When an NPC has the hit point field as just text, it would throw a nil value error when trying to call function convertSingleNumberTextToNumber.  I just added an if statement to skip this call if the field contained no numbers.